### PR TITLE
MTN make the benchmark compatible with latest API changes

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -9,7 +9,7 @@ with safe_import_context() as import_ctx:
 class Objective(BaseObjective):
     name = "Bilevel Optimization"
 
-    min_benchopt_version = "1.1.1"
+    min_benchopt_version = "1.4.1"
 
     parameters = {
         'random_state': [2442]

--- a/objective.py
+++ b/objective.py
@@ -43,9 +43,7 @@ class Objective(BaseObjective):
             self.outer_var0 = -2 * np.ones(*outer_shape)
             # XXX: Try random inits
 
-    def compute(self, beta):
-        inner_var, outer_var = beta
-
+    def evaluate_result(self, inner_var, outer_var):
         if np.isnan(outer_var).any():
             raise ValueError
 

--- a/objective.py
+++ b/objective.py
@@ -9,7 +9,7 @@ with safe_import_context() as import_ctx:
 class Objective(BaseObjective):
     name = "Bilevel Optimization"
 
-    min_benchopt_version = "1.3.2"
+    min_benchopt_version = "1.4.1"
 
     parameters = {
         'random_state': [2442]

--- a/objective.py
+++ b/objective.py
@@ -9,7 +9,7 @@ with safe_import_context() as import_ctx:
 class Objective(BaseObjective):
     name = "Bilevel Optimization"
 
-    min_benchopt_version = "1.4.1"
+    min_benchopt_version = "1.1.1"
 
     parameters = {
         'random_state': [2442]

--- a/objective.py
+++ b/objective.py
@@ -20,7 +20,8 @@ class Objective(BaseObjective):
 
     def get_one_solution(self):
         inner_shape, outer_shape = self.get_inner_oracle().variables_shape
-        return np.zeros(*inner_shape), np.zeros(*outer_shape)
+        return dict(inner_var=np.zeros(*inner_shape),
+                    outer_var=np.zeros(*outer_shape))
 
     def set_data(self, get_inner_oracle, get_outer_oracle, oracle, metrics,
                  n_reg):

--- a/solvers/amigo.py
+++ b/solvers/amigo.py
@@ -136,8 +136,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -145,8 +145,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == 'jax':
             v = jnp.zeros_like(inner_var)
             step_sizes = jnp.array(
@@ -206,11 +206,11 @@ class Solver(BaseSolver):
                     n_v_steps=self.n_inner_steps, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _amigo(sgd_inner, sgd_v, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/amigo.py
+++ b/solvers/amigo.py
@@ -190,7 +190,7 @@ class Solver(BaseSolver):
                 self.f_inner, inner_var, outer_var, self.step_size,
                 sampler=inner_sampler, n_steps=self.n_inner_steps,
             )
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, v, carry = self.amigo(
                         self.f_inner, self.f_outer, inner_var, outer_var, v,

--- a/solvers/amigo.py
+++ b/solvers/amigo.py
@@ -306,6 +306,6 @@ def amigo_jax(f_inner, f_outer, inner_var, outer_var, v,
         xs=None,
         length=max_iter,
     )
-    return carry['inner_var'], carry['outer_var'], carry['v'],\
+    return carry['inner_var'], carry['outer_var'], carry['v'], \
         {k: v for k, v in carry.items()
          if k not in ['inner_var', 'outer_var', 'v']}

--- a/solvers/amigo.py
+++ b/solvers/amigo.py
@@ -210,7 +210,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _amigo(sgd_inner, sgd_v, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/amigo.py
+++ b/solvers/amigo.py
@@ -190,7 +190,7 @@ class Solver(BaseSolver):
                 self.f_inner, inner_var, outer_var, self.step_size,
                 sampler=inner_sampler, n_steps=self.n_inner_steps,
             )
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, v, carry = self.amigo(
                         self.f_inner, self.f_outer, inner_var, outer_var, v,

--- a/solvers/bsa.py
+++ b/solvers/bsa.py
@@ -187,7 +187,7 @@ class Solver(BaseSolver):
                 step_size=self.step_size, sampler=inner_sampler,
                 n_steps=self.n_inner_steps
             )
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.bsa(
                         self.f_inner, self.f_outer, inner_var, outer_var,

--- a/solvers/bsa.py
+++ b/solvers/bsa.py
@@ -187,7 +187,7 @@ class Solver(BaseSolver):
                 step_size=self.step_size, sampler=inner_sampler,
                 n_steps=self.n_inner_steps
             )
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.bsa(
                         self.f_inner, self.f_outer, inner_var, outer_var,

--- a/solvers/bsa.py
+++ b/solvers/bsa.py
@@ -132,8 +132,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -141,8 +141,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq
 
         # Init variables
-        outer_var = self.outer_var0.copy()
-        inner_var = self.inner_var0.copy()
+        outer_var = self.outer_var.copy()
+        inner_var = self.inner_var.copy()
 
         if self.framework == 'jax':
             step_sizes = jnp.array(
@@ -203,11 +203,11 @@ class Solver(BaseSolver):
                     n_hia_steps=self.n_hia_steps, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _bsa(sgd_inner, hia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/bsa.py
+++ b/solvers/bsa.py
@@ -207,7 +207,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _bsa(sgd_inner, hia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/fsla.py
+++ b/solvers/fsla.py
@@ -159,7 +159,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, v, memory_outer, carry = self.fsla(
                     self.f_inner, self.f_outer,

--- a/solvers/fsla.py
+++ b/solvers/fsla.py
@@ -111,8 +111,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -120,8 +120,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq  # // self.batch_size
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == 'jax':
             v = jnp.zeros_like(inner_var)
             memory_outer = jnp.zeros((2, *outer_var.shape))
@@ -175,10 +175,11 @@ class Solver(BaseSolver):
                     lr_scheduler=lr_scheduler, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def fsla(inner_oracle, outer_oracle, inner_var, outer_var, v, memory_outer,

--- a/solvers/fsla.py
+++ b/solvers/fsla.py
@@ -178,7 +178,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def fsla(inner_oracle, outer_oracle, inner_var, outer_var, v, memory_outer,

--- a/solvers/fsla.py
+++ b/solvers/fsla.py
@@ -159,7 +159,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, v, memory_outer, carry = self.fsla(
                     self.f_inner, self.f_outer,

--- a/solvers/jaxopt_gd.py
+++ b/solvers/jaxopt_gd.py
@@ -81,16 +81,16 @@ class Solver(BaseSolver):
                                         f=self.f_inner,
                                         n_steps=self.n_inner_steps)
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         self.run_once(2)
 
     def run(self, callback):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
 
         step_sizes = jnp.array(
             [self.step_size_outer]
@@ -112,7 +112,8 @@ class Solver(BaseSolver):
 
                 implicit_grad = grad_outer_out + jvp_fun(grad_outer_in)[0]
                 outer_var -= outer_lr * implicit_grad
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)

--- a/solvers/jaxopt_gd.py
+++ b/solvers/jaxopt_gd.py
@@ -99,7 +99,7 @@ class Solver(BaseSolver):
         state_lr = init_lr_scheduler(step_sizes, exponents)
 
         grad_outer = jax.jit(jax.grad(self.f_outer, argnums=(0, 1)))
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             for _ in range(eval_freq):
                 outer_lr, state_lr = update_lr(state_lr)
 

--- a/solvers/jaxopt_gd.py
+++ b/solvers/jaxopt_gd.py
@@ -99,7 +99,7 @@ class Solver(BaseSolver):
         state_lr = init_lr_scheduler(step_sizes, exponents)
 
         grad_outer = jax.jit(jax.grad(self.f_outer, argnums=(0, 1)))
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             for _ in range(eval_freq):
                 outer_lr, state_lr = update_lr(state_lr)
 

--- a/solvers/jaxopt_gd.py
+++ b/solvers/jaxopt_gd.py
@@ -115,4 +115,4 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])

--- a/solvers/jaxopt_itd.py
+++ b/solvers/jaxopt_itd.py
@@ -97,7 +97,7 @@ class Solver(BaseSolver):
 
         grad_outer = jax.jit(jax.grad(self.f_outer, argnums=(0, 1)))
 
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             for _ in range(eval_freq):
                 outer_lr, state_lr = update_lr(state_lr)
                 init_inner = inner_var if self.warm_start else self.inner_var0

--- a/solvers/jaxopt_itd.py
+++ b/solvers/jaxopt_itd.py
@@ -78,16 +78,16 @@ class Solver(BaseSolver):
                                         f=self.f_inner,
                                         n_steps=self.n_inner_steps)
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         self.run_once(2)
 
     def run(self, callback):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
 
         step_sizes = jnp.array(
             [self.step_size_outer]
@@ -110,8 +110,8 @@ class Solver(BaseSolver):
 
                 implicit_grad = grad_outer_out + jvp_fun(grad_outer_in)[0]
                 outer_var -= outer_lr * implicit_grad
-
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)

--- a/solvers/jaxopt_itd.py
+++ b/solvers/jaxopt_itd.py
@@ -97,7 +97,7 @@ class Solver(BaseSolver):
 
         grad_outer = jax.jit(jax.grad(self.f_outer, argnums=(0, 1)))
 
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             for _ in range(eval_freq):
                 outer_lr, state_lr = update_lr(state_lr)
                 init_inner = inner_var if self.warm_start else self.inner_var0

--- a/solvers/jaxopt_itd.py
+++ b/solvers/jaxopt_itd.py
@@ -114,4 +114,4 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])

--- a/solvers/mrbo.py
+++ b/solvers/mrbo.py
@@ -122,8 +122,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -131,8 +131,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == 'jax':
             memory_inner = jnp.zeros((2, *inner_var.shape), inner_var.dtype)
             memory_outer = jnp.zeros((2, *outer_var.shape), outer_var.dtype)
@@ -193,10 +193,11 @@ class Solver(BaseSolver):
                     lr_scheduler, n_shia_steps=self.n_shia_steps,
                     max_iter=eval_freq, seed=rng.randint(constants.MAX_SEED)
                 )
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _mrbo(joint_shia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/mrbo.py
+++ b/solvers/mrbo.py
@@ -196,7 +196,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _mrbo(joint_shia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/mrbo.py
+++ b/solvers/mrbo.py
@@ -347,7 +347,7 @@ def mrbo_jax(f_inner, f_outer, inner_var, outer_var, memory_inner,
         xs=None,
         length=max_iter,
     )
-    return carry['inner_var'], carry['outer_var'], carry['memory_inner'],\
+    return carry['inner_var'], carry['outer_var'], carry['memory_inner'], \
         carry['memory_outer'], \
         {k: v for k, v in carry.items()
          if k not in ['inner_var', 'outer_var', 'memory_inner',

--- a/solvers/mrbo.py
+++ b/solvers/mrbo.py
@@ -134,8 +134,8 @@ class Solver(BaseSolver):
         inner_var = self.inner_var.copy()
         outer_var = self.outer_var.copy()
         if self.framework == 'jax':
-            memory_inner = jnp.zeros((2, *inner_var.shape), inner_var.dtype)
-            memory_outer = jnp.zeros((2, *outer_var.shape), outer_var.dtype)
+            memory_inner = jnp.zeros((2, *inner_var.shape))
+            memory_outer = jnp.zeros((2, *outer_var.shape))
             step_sizes = jnp.array(  # (inner_ss, hia_lr, eta, outer_ss)
                 [
                     self.step_size,

--- a/solvers/mrbo.py
+++ b/solvers/mrbo.py
@@ -177,7 +177,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, memory_inner, memory_outer, \
                     carry = self.mrbo(

--- a/solvers/mrbo.py
+++ b/solvers/mrbo.py
@@ -177,7 +177,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, memory_inner, memory_outer, \
                     carry = self.mrbo(

--- a/solvers/optuna.py
+++ b/solvers/optuna.py
@@ -63,4 +63,4 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])

--- a/solvers/optuna.py
+++ b/solvers/optuna.py
@@ -29,8 +29,8 @@ class Solver(BaseSolver):
 
     def set_objective(self, f_train, f_val, n_inner_samples, n_outer_samples,
                       inner_var0, outer_var0):
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
 
         self.f_inner = f_train(framework='none')
         self.f_outer = f_val(framework='none')
@@ -38,17 +38,17 @@ class Solver(BaseSolver):
     def run(self, n_iter):
         optuna.logging.set_verbosity(optuna.logging.WARNING)
         if n_iter == 0:
-            outer_var = self.outer_var0.copy()
+            outer_var = self.outer_var.copy()
         else:
             def obj_optuna(trial):
-                outer_var_flat = self.outer_var0.ravel()
+                outer_var_flat = self.outer_var.ravel()
                 for k in range(len(outer_var_flat)):
                     outer_var_flat[k] = trial.suggest_float(
                         f'outer_var{k}',
                         -15,
                         5
                     )
-                outer_var = outer_var_flat.reshape(self.outer_var0.shape)
+                outer_var = outer_var_flat.reshape(self.outer_var.shape)
                 inner_var = self.f_inner.get_inner_var_star(outer_var)
                 return self.f_outer.get_value(inner_var, outer_var)
 
@@ -59,8 +59,8 @@ class Solver(BaseSolver):
             outer_var = np.array(list(trial.params.values())).reshape(
                 self.outer_var0.shape
             )
-        inner_var = self.f_inner.get_inner_var_star(outer_var)
-        self.beta = (inner_var, outer_var)
+        self.inner_var = self.f_inner.get_inner_var_star(outer_var)
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)

--- a/solvers/pzobo.py
+++ b/solvers/pzobo.py
@@ -157,7 +157,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _pzobo(gd_inner, inner_oracle, outer_oracle, inner_var, outer_var, mu=.1,

--- a/solvers/pzobo.py
+++ b/solvers/pzobo.py
@@ -135,7 +135,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.pzobo(
                     self.f_inner, self.f_outer,

--- a/solvers/pzobo.py
+++ b/solvers/pzobo.py
@@ -135,7 +135,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.pzobo(
                     self.f_inner, self.f_outer,

--- a/solvers/pzobo.py
+++ b/solvers/pzobo.py
@@ -97,8 +97,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -106,8 +106,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == "jax":
             # Init lr scheduler
             step_sizes = jnp.array(
@@ -153,11 +153,11 @@ class Solver(BaseSolver):
                     lr_scheduler=lr_scheduler, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _pzobo(gd_inner, inner_oracle, outer_oracle, inner_var, outer_var, mu=.1,

--- a/solvers/saba.py
+++ b/solvers/saba.py
@@ -199,7 +199,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, v, memory, carry = self.saba(
                     self.f_inner, self.f_outer,

--- a/solvers/saba.py
+++ b/solvers/saba.py
@@ -140,8 +140,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -149,8 +149,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq  # // self.batch_size
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == 'jax':
             v = jnp.zeros_like(inner_var)
 
@@ -214,11 +214,11 @@ class Solver(BaseSolver):
                     lr_scheduler=lr_scheduler, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _init_memory(

--- a/solvers/saba.py
+++ b/solvers/saba.py
@@ -218,7 +218,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _init_memory(

--- a/solvers/saba.py
+++ b/solvers/saba.py
@@ -199,7 +199,7 @@ class Solver(BaseSolver):
             )
 
         # Start algorithm
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, v, memory, carry = self.saba(
                     self.f_inner, self.f_outer,

--- a/solvers/soba.py
+++ b/solvers/soba.py
@@ -157,7 +157,7 @@ class Solver(BaseSolver):
                                                   self.batch_size_outer)
 
         # Start algorithm
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, v, carry = self.soba(
                     self.f_inner, self.f_outer,

--- a/solvers/soba.py
+++ b/solvers/soba.py
@@ -111,8 +111,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -120,8 +120,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == "jax":
             v = jnp.zeros_like(inner_var)
             # Init lr scheduler
@@ -172,11 +172,11 @@ class Solver(BaseSolver):
                     lr_scheduler=lr_scheduler, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def soba(inner_oracle, outer_oracle, inner_var, outer_var, v,

--- a/solvers/soba.py
+++ b/solvers/soba.py
@@ -157,7 +157,7 @@ class Solver(BaseSolver):
                                                   self.batch_size_outer)
 
         # Start algorithm
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, v, carry = self.soba(
                     self.f_inner, self.f_outer,

--- a/solvers/soba.py
+++ b/solvers/soba.py
@@ -176,7 +176,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def soba(inner_oracle, outer_oracle, inner_var, outer_var, v,

--- a/solvers/soba.py
+++ b/solvers/soba.py
@@ -262,6 +262,6 @@ def soba_jax(f_inner, f_outer, inner_var, outer_var, v,
         xs=None,
         length=max_iter,
     )
-    return carry['inner_var'], carry['outer_var'], carry['v'],\
+    return carry['inner_var'], carry['outer_var'], carry['v'], \
         {k: v for k, v in carry.items()
          if k not in ['inner_var', 'outer_var', 'v']}

--- a/solvers/srba.py
+++ b/solvers/srba.py
@@ -191,7 +191,7 @@ class Solver(BaseSolver):
         v_old = v.copy()
         i_min = 0
         # Start algorithm
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             # print("===")
             if self.framework == "jax":
                 # with jax.disable_jit():

--- a/solvers/srba.py
+++ b/solvers/srba.py
@@ -191,7 +191,7 @@ class Solver(BaseSolver):
         v_old = v.copy()
         i_min = 0
         # Start algorithm
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == "jax":
                 inner_var, outer_var, v, inner_var_old, outer_var_old, \
                     v_old, d_inner, d_v, d_outer, carry = self.srba(

--- a/solvers/srba.py
+++ b/solvers/srba.py
@@ -218,7 +218,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def srba(

--- a/solvers/srba.py
+++ b/solvers/srba.py
@@ -124,8 +124,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -133,8 +133,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq  # // self.batch_size
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
 
         if self.framework == "jax":
             v = jnp.zeros_like(inner_var)
@@ -213,10 +213,11 @@ class Solver(BaseSolver):
                         i_min=i_min, period=period, max_iter=eval_freq,
                         seed=rng.randint(constants.MAX_SEED)
                     )
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def srba(

--- a/solvers/srba.py
+++ b/solvers/srba.py
@@ -202,7 +202,7 @@ class Solver(BaseSolver):
                         **carry
                     )
             else:
-                inner_var, outer_var, v, inner_var_old, outer_var_old,\
+                inner_var, outer_var, v, inner_var_old, outer_var_old, \
                     v_old, d_inner, d_v, d_outer, i_min = self.srba(
                         self.f_inner, self.f_outer,
                         inner_var, outer_var, v,

--- a/solvers/srba.py
+++ b/solvers/srba.py
@@ -192,9 +192,7 @@ class Solver(BaseSolver):
         i_min = 0
         # Start algorithm
         while callback(dict(inner_var=inner_var, outer_var=outer_var)):
-            # print("===")
             if self.framework == "jax":
-                # with jax.disable_jit():
                 inner_var, outer_var, v, inner_var_old, outer_var_old, \
                     v_old, d_inner, d_v, d_outer, carry = self.srba(
                         self.f_inner, self.f_outer, self.f_inner_fb,

--- a/solvers/stocbio.py
+++ b/solvers/stocbio.py
@@ -190,7 +190,7 @@ class Solver(BaseSolver):
                 step_size=self.step_size, sampler=inner_sampler,
                 n_steps=self.n_inner_steps
             )
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.stocbio(
                         self.f_inner, self.f_outer, inner_var, outer_var,

--- a/solvers/stocbio.py
+++ b/solvers/stocbio.py
@@ -136,8 +136,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -145,8 +145,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq  # // self.batch_size
 
         # Init variables
-        outer_var = self.outer_var0.copy()
-        inner_var = self.inner_var0.copy()
+        outer_var = self.outer_var.copy()
+        inner_var = self.inner_var.copy()
 
         if self.framework == 'jax':
             step_sizes = jnp.array(
@@ -206,11 +206,11 @@ class Solver(BaseSolver):
                     n_shia_steps=self.n_shia_steps, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _stocbio(sgd_inner, shia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/stocbio.py
+++ b/solvers/stocbio.py
@@ -210,7 +210,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _stocbio(sgd_inner, shia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/stocbio.py
+++ b/solvers/stocbio.py
@@ -190,7 +190,7 @@ class Solver(BaseSolver):
                 step_size=self.step_size, sampler=inner_sampler,
                 n_steps=self.n_inner_steps
             )
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.stocbio(
                         self.f_inner, self.f_outer, inner_var, outer_var,

--- a/solvers/sustain.py
+++ b/solvers/sustain.py
@@ -175,7 +175,7 @@ class Solver(BaseSolver):
                 np.array(step_sizes, dtype=float), exponents
             )
 
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, memory_inner, memory_outer, \
                     carry = self.sustain(

--- a/solvers/sustain.py
+++ b/solvers/sustain.py
@@ -134,8 +134,8 @@ class Solver(BaseSolver):
         inner_var = self.inner_var.copy()
         outer_var = self.outer_var.copy()
         if self.framework == 'jax':
-            memory_inner = jnp.zeros((2, *inner_var.shape), inner_var.dtype)
-            memory_outer = jnp.zeros((2, *outer_var.shape), outer_var.dtype)
+            memory_inner = jnp.zeros((2, *inner_var.shape))
+            memory_outer = jnp.zeros((2, *outer_var.shape))
             step_sizes = jnp.array(  # (inner_ss, hia_lr, eta, outer_ss)
                 [
                     self.step_size,

--- a/solvers/sustain.py
+++ b/solvers/sustain.py
@@ -348,7 +348,7 @@ def sustain_jax(f_inner, f_outer, inner_var, outer_var, memory_inner,
         xs=None,
         length=max_iter,
     )
-    return carry['inner_var'], carry['outer_var'], carry['memory_inner'],\
+    return carry['inner_var'], carry['outer_var'], carry['memory_inner'], \
         carry['memory_outer'], \
         {k: v for k, v in carry.items()
          if k not in ['inner_var', 'outer_var', 'memory_inner',

--- a/solvers/sustain.py
+++ b/solvers/sustain.py
@@ -122,8 +122,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -131,8 +131,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == 'jax':
             memory_inner = jnp.zeros((2, *inner_var.shape), inner_var.dtype)
             memory_outer = jnp.zeros((2, *outer_var.shape), outer_var.dtype)
@@ -192,10 +192,11 @@ class Solver(BaseSolver):
                                  n_hia_steps=self.n_hia_steps,
                                  max_iter=eval_freq,
                                  seed=rng.randint(constants.MAX_SEED))
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _sustain(joint_hia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/sustain.py
+++ b/solvers/sustain.py
@@ -175,7 +175,7 @@ class Solver(BaseSolver):
                 np.array(step_sizes, dtype=float), exponents
             )
 
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, memory_inner, memory_outer, \
                     carry = self.sustain(

--- a/solvers/sustain.py
+++ b/solvers/sustain.py
@@ -195,7 +195,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _sustain(joint_hia, inner_oracle, outer_oracle, inner_var, outer_var,

--- a/solvers/ttsa.py
+++ b/solvers/ttsa.py
@@ -164,7 +164,7 @@ class Solver(BaseSolver):
                 np.array(step_sizes, dtype=float), exponents
             )
 
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.ttsa(
                         self.f_inner, self.f_outer, inner_var, outer_var,

--- a/solvers/ttsa.py
+++ b/solvers/ttsa.py
@@ -164,7 +164,7 @@ class Solver(BaseSolver):
                 np.array(step_sizes, dtype=float), exponents
             )
 
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 inner_var, outer_var, carry = self.ttsa(
                         self.f_inner, self.f_outer, inner_var, outer_var,

--- a/solvers/ttsa.py
+++ b/solvers/ttsa.py
@@ -181,7 +181,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _ttsa(

--- a/solvers/ttsa.py
+++ b/solvers/ttsa.py
@@ -123,8 +123,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -132,8 +132,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
         if self.framework == 'jax':
             step_sizes = jnp.array(
                 [self.step_size, self.step_size,
@@ -178,10 +178,11 @@ class Solver(BaseSolver):
                     n_hia_steps=self.n_hia_steps, max_iter=eval_freq,
                     seed=rng.randint(constants.MAX_SEED)
                 )
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _ttsa(

--- a/solvers/vrbo.py
+++ b/solvers/vrbo.py
@@ -253,7 +253,7 @@ class Solver(BaseSolver):
         self.beta = (inner_var, outer_var)
 
     def get_result(self):
-        return self.beta
+        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
 
 
 def _vrbo(

--- a/solvers/vrbo.py
+++ b/solvers/vrbo.py
@@ -167,8 +167,8 @@ class Solver(BaseSolver):
         else:
             raise ValueError(f"Framework {self.framework} not supported.")
 
-        self.inner_var0 = inner_var0
-        self.outer_var0 = outer_var0
+        self.inner_var = inner_var0
+        self.outer_var = outer_var0
         if self.framework == 'numba' or self.framework == 'jax':
             self.run_once(2)
 
@@ -176,8 +176,8 @@ class Solver(BaseSolver):
         eval_freq = self.eval_freq  # // self.batch_size
 
         # Init variables
-        inner_var = self.inner_var0.copy()
-        outer_var = self.outer_var0.copy()
+        inner_var = self.inner_var.copy()
+        outer_var = self.outer_var.copy()
 
         period = self.n_inner_samples + self.n_outer_samples
         period *= self.period_frac
@@ -250,10 +250,11 @@ class Solver(BaseSolver):
                         i_min=i_min, period=period,
                         seed=rng.randint(constants.MAX_SEED)
                     )
-        self.beta = (inner_var, outer_var)
+        self.inner_var = inner_var
+        self.outer_var = outer_var
 
     def get_result(self):
-        return dict(inner_var=self.beta[0], outer_var=self.beta[1])
+        return dict(inner_var=self.inner_var, outer_var=self.outer_var)
 
 
 def _vrbo(

--- a/solvers/vrbo.py
+++ b/solvers/vrbo.py
@@ -228,7 +228,7 @@ class Solver(BaseSolver):
             )
         i_min = 0
         # Start algorithm
-        while callback((inner_var, outer_var)):
+        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
             if self.framework == 'jax':
                 # with jax.disable_jit():
                 inner_var, outer_var, inner_var_old, d_inner, d_outer, \

--- a/solvers/vrbo.py
+++ b/solvers/vrbo.py
@@ -228,7 +228,7 @@ class Solver(BaseSolver):
             )
         i_min = 0
         # Start algorithm
-        while callback(dict(inner_var=inner_var, outer_var=outer_var)):
+        while callback():
             if self.framework == 'jax':
                 # with jax.disable_jit():
                 inner_var, outer_var, inner_var_old, d_inner, d_outer, \


### PR DESCRIPTION
This PR makes the template benchmark with the latest API changes
* `objective.compute` becomes `objective.evaluate_result`
* `solver.get_result` returns a dict
* ~`callback` takes a dict as argument~
* `get_one_solution` returns a dict

