### PR TITLE
Add possibility to have pytrees as variables

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -14,9 +14,7 @@ class Objective(BaseObjective):
     requirements = ["scikit-learn", "jax", "jaxlib"]
     min_benchopt_version = "1.5"
 
-    parameters = {
-        'random_state': [2442]
-    }
+    parameters = {"random_state": [2442]}
 
     def __init__(self, random_state=2442):
         self.random_state = random_state
@@ -24,16 +22,18 @@ class Objective(BaseObjective):
     def get_one_result(self):
         inner_shape, outer_shape = self.dim_inner, self.dim_outer
         return dict(
-            inner_var=jax.tree_util.tree_map(jnp.zeros, inner_shape, is_leaf=lambda x: isinstance(x, tuple)),  # can be a pytree
-            outer_var=jax.tree_util.tree_map(jnp.zeros, outer_shape, is_leaf=lambda x: isinstance(x, tuple)),
+            inner_var=jax.tree_util.tree_map(
+                jnp.zeros, inner_shape, is_leaf=lambda x: isinstance(x, tuple)
+            ),  # can be a pytree
+            outer_var=jax.tree_util.tree_map(
+                jnp.zeros, outer_shape, is_leaf=lambda x: isinstance(x, tuple)
+            ),
         )
 
     def set_data(self, pb_inner, pb_outer, metrics, init_var=None):
 
-        (self.f_inner, self.n_samples_inner, self.dim_inner,
-         self.f_inner_fb) = pb_inner
-        (self.f_outer, self.n_samples_outer, self.dim_outer,
-         self.f_outer_fb) = pb_outer
+        (self.f_inner, self.n_samples_inner, self.dim_inner, self.f_inner_fb) = pb_inner
+        (self.f_outer, self.n_samples_outer, self.dim_outer, self.f_outer_fb) = pb_outer
         self.metrics = metrics
 
         key = jax.random.PRNGKey(self.random_state)
@@ -41,11 +41,20 @@ class Objective(BaseObjective):
             # Define random inits per datasets
             self.inner_var0, self.outer_var0 = init_var(key)
         else:
-            self.inner_var0 = jax.tree_util.tree_map(jnp.zeros, self.dim_inner, is_leaf=lambda x: isinstance(x, tuple))
-            self.outer_var0 = jax.tree_util.tree_map(lambda x: - 2 * jnp.ones(x), self.dim_outer, is_leaf=lambda x: isinstance(x, tuple))
+            self.inner_var0 = jax.tree_util.tree_map(
+                jnp.zeros, self.dim_inner, is_leaf=lambda x: isinstance(x, tuple)
+            )
+            self.outer_var0 = jax.tree_util.tree_map(
+                lambda x: -2 * jnp.ones(x),
+                self.dim_outer,
+                is_leaf=lambda x: isinstance(x, tuple),
+            )
 
     def evaluate_result(self, inner_var, outer_var):
-        if jax.tree_util.tree_reduce(operator.or_, jax.tree_util.tree_map(lambda x: jnp.isnan(x).any(), outer_var)):
+        if jax.tree_util.tree_reduce(
+            operator.or_,
+            jax.tree_util.tree_map(lambda x: jnp.isnan(x).any(), outer_var),
+        ):
             raise ValueError
 
         metrics = self.metrics(inner_var, outer_var)
@@ -58,5 +67,5 @@ class Objective(BaseObjective):
             n_inner_samples=self.n_samples_inner,
             n_outer_samples=self.n_samples_outer,
             inner_var0=self.inner_var0,
-            outer_var0=self.outer_var0
+            outer_var0=self.outer_var0,
         )

--- a/objective.py
+++ b/objective.py
@@ -34,7 +34,7 @@ class Objective(BaseObjective):
                 jnp.zeros,
                 outer_shape,
                 is_leaf=lambda x: isinstance(x, tuple),
-            ),
+            ),  # build a new tree full of zeros with the outer_shape structure
         )
 
     def set_data(self, pb_inner, pb_outer, metrics, init_var=None):
@@ -62,12 +62,12 @@ class Objective(BaseObjective):
                 jnp.zeros,
                 self.dim_inner,
                 is_leaf=lambda x: isinstance(x, tuple),
-            )
+            )  # build a new tree full of zeros with the dim_inner structure
             self.outer_var0 = jax.tree_util.tree_map(
                 lambda x: -2 * jnp.ones(x),
                 self.dim_outer,
                 is_leaf=lambda x: isinstance(x, tuple),
-            )
+            )  # build a new tree full of zeros with the dim_outer structure
 
     def evaluate_result(self, inner_var, outer_var):
         if jax.tree_util.tree_reduce(

--- a/objective.py
+++ b/objective.py
@@ -20,20 +20,37 @@ class Objective(BaseObjective):
         self.random_state = random_state
 
     def get_one_result(self):
-        inner_shape, outer_shape = self.dim_inner, self.dim_outer
+        inner_shape, outer_shape = (
+            self.dim_inner,
+            self.dim_outer,
+        )
         return dict(
             inner_var=jax.tree_util.tree_map(
-                jnp.zeros, inner_shape, is_leaf=lambda x: isinstance(x, tuple)
+                jnp.zeros,
+                inner_shape,
+                is_leaf=lambda x: isinstance(x, tuple),
             ),  # can be a pytree
             outer_var=jax.tree_util.tree_map(
-                jnp.zeros, outer_shape, is_leaf=lambda x: isinstance(x, tuple)
+                jnp.zeros,
+                outer_shape,
+                is_leaf=lambda x: isinstance(x, tuple),
             ),
         )
 
     def set_data(self, pb_inner, pb_outer, metrics, init_var=None):
 
-        (self.f_inner, self.n_samples_inner, self.dim_inner, self.f_inner_fb) = pb_inner
-        (self.f_outer, self.n_samples_outer, self.dim_outer, self.f_outer_fb) = pb_outer
+        (
+            self.f_inner,
+            self.n_samples_inner,
+            self.dim_inner,
+            self.f_inner_fb,
+        ) = pb_inner
+        (
+            self.f_outer,
+            self.n_samples_outer,
+            self.dim_outer,
+            self.f_outer_fb,
+        ) = pb_outer
         self.metrics = metrics
 
         key = jax.random.PRNGKey(self.random_state)
@@ -42,7 +59,9 @@ class Objective(BaseObjective):
             self.inner_var0, self.outer_var0 = init_var(key)
         else:
             self.inner_var0 = jax.tree_util.tree_map(
-                jnp.zeros, self.dim_inner, is_leaf=lambda x: isinstance(x, tuple)
+                jnp.zeros,
+                self.dim_inner,
+                is_leaf=lambda x: isinstance(x, tuple),
             )
             self.outer_var0 = jax.tree_util.tree_map(
                 lambda x: -2 * jnp.ones(x),


### PR DESCRIPTION
This allows to have pytrees as inner, outer variables. This should not break when inner and outer variables are arrays.